### PR TITLE
Update feeds

### DIFF
--- a/data/feeds.json
+++ b/data/feeds.json
@@ -152,6 +152,10 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "crvUSD/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "CRVUSD/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -197,6 +201,10 @@
   },
   {
     "name": "EUR/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "EURe/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
@@ -368,6 +376,10 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "miMATIC/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "MIMATIC/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -424,6 +436,10 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "osETH/ETH Exchange Rate",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "OSMO/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -445,6 +461,10 @@
   },
   {
     "name": "PYTH/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "PYUSD/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
@@ -544,6 +564,10 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "stMATIC/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "STMATIC/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -553,6 +577,10 @@
   },
   {
     "name": "SUI/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "sUSD/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
@@ -592,6 +620,10 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "uniETH/ETH Exchange Rate",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "USDC/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -609,6 +641,14 @@
   },
   {
     "name": "WBTC/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "weETH/ETH Exchange Rate",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "WLD/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {


### PR DESCRIPTION
See related issues: https://github.com/api3dao/tasks/issues/598 and https://github.com/api3dao/tasks/issues/605

---

Following pairs are added:

**Stable:**

1. PYUSD/USD
2. EURe/USD (will replace EURE/USD)
3. crvUSD/USD (will replace CRVUSD/USD)
4. stMATIC/USD (will replace STMATIC/USD)
5. miMATIC/USD (will replace MIMATIC/USD)
6. sUSD/USD (will replace SUSD/USD)

**Crypto:**

1. WLD/USD

**LSD:**

1. uniETH/ETH Exchange Rate
8. osETH/ETH Exchange Rate
9. weETH/ETH Exchange Rate