### PR TITLE
Downgrade @api3/chains to 4.7.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,18 @@
-name: test
+name: Continuous Build
 
 on: [push]
 
 jobs:
-  test:
+  lint-and-validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: "18"
       - name: Install dependencies
         run: yarn
       - name: Lint
         run: yarn lint
+      - name: Check @api3/chains coverage
+        run: yarn chains:coverage

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@api3/airnode-abi": "^0.10.0",
-    "@api3/chains": "^4.8.0",
+    "@api3/chains": "4.7.0",
     "ethers": "^6.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint": "yarn run prettier:check && yarn run lint:eslint",
     "lint:eslint": "eslint . --ext .js,.ts",
     "prettier:check": "prettier --check \"./**/*.{js,ts,md,json,sol}\"",
-    "prettier": "prettier --write \"./**/*.{js,ts,md,json,sol}\""
+    "prettier": "prettier --write \"./**/*.{js,ts,md,json,sol}\"",
+    "chains:coverage": "node -e 'console.log(require(\"./src/index\").nodaryChainIds())'"
   },
   "devDependencies": {
     "eslint": "^8.36.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,10 @@
     ethers "^5.7.2"
     lodash "^4.17.21"
 
-"@api3/chains@^4.8.0":
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/@api3/chains/-/chains-4.8.0.tgz#012319f45077063e56a1fc0906ae5516a40e411f"
-  integrity sha512-58JeZcaIktqOjvH4z9jHPIdDZZdVBh7V19bnEsljwwf0KHIVd//59w2vKVOfzi8UjuRjws00ndjq4YdRXdVjIA==
+"@api3/chains@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@api3/chains/-/chains-4.7.0.tgz#fdb20cc61974d9498d30785a53725200551cf126"
+  integrity sha512-H40HUw7TKYC+PFGKFRpzrBnMhOz1vjK3g4oDzM1J6hMEOX2L8wlbhvP3LbDf0OUoMuLfwq7FdTPSJNDAXAOPfA==
   dependencies:
     viem "^2.7.1"
     zod "^3.22.4"


### PR DESCRIPTION
[Removing `base-goerli-testnet`](https://github.com/api3dao/chains/pull/181) breaks the package, so this downgrade is required. I also added validation to CI flow to not experience this issue again.