### PR TITLE
Retire feed support for EURe/USD, MTL/USD, and RLP/USD

### DIFF
--- a/.changeset/lazy-falcons-retire.md
+++ b/.changeset/lazy-falcons-retire.md
@@ -1,0 +1,9 @@
+---
+"@nodary/utilities": major
+---
+
+Retire following feeds:
+
+- EURe/USD
+- MTL/USD
+- RLP/USD

--- a/data/feeds.json
+++ b/data/feeds.json
@@ -180,10 +180,6 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
-    "name": "EURe/USD",
-    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
-  },
-  {
     "name": "ezETH/ETH Exchange Rate",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -308,10 +304,6 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
-    "name": "MTL/USD",
-    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
-  },
-  {
     "name": "MVL/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -365,10 +357,6 @@
   },
   {
     "name": "rETH/ETH Exchange Rate",
-    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
-  },
-  {
-    "name": "RLP/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {


### PR DESCRIPTION
As a part of https://github.com/api3dao/internal-operations/issues/1938.